### PR TITLE
Optional JSON output for kbupctl status

### DIFF
--- a/service/kbupd/Cargo.toml
+++ b/service/kbupd/Cargo.toml
@@ -35,7 +35,8 @@ prost            = "0.5"
 rand             = "0.6"
 ring             = "0.14"
 route-recognizer = "0.1"
-serde            = "1.0"
+serde            = { version = "1.0", features = ["derive"] }
+serde_with       = { version = "1.7.0", features = ["hex"]}
 serde_derive     = "1.0"
 serde_json       = "1.0"
 serde_yaml       = "0.8"

--- a/service/kbupd/build.rs
+++ b/service/kbupd/build.rs
@@ -17,6 +17,26 @@ fn main() {
 
     let mut protoc = prost_build::Config::new();
     protoc
+        .type_attribute(".", "#[derive(serde::Serialize)]")
+        .field_attribute("node_id", "#[serde(with = \"serde_with::As::<serde_with::hex::Hex>\")]")
+        .field_attribute(
+            "EnclaveFrontendPartitionStatus.group_id",
+            "#[serde(with = \"serde_with::As::<serde_with::hex::Hex>\")]",
+        )
+        .field_attribute(
+            "EnclaveFrontendRangeStatus.group_id",
+            "#[serde(with = \"serde_with::As::<serde_with::hex::Hex>\")]",
+        )
+        .field_attribute(
+            "EnclaveReplicaPartitionStatus.group_id",
+            "#[serde(with = \"serde_with::As::<serde_with::hex::Hex>\")]",
+        )
+        .field_attribute(
+            "EnclaveReplicaPartitionStatus.service_id",
+            "#[serde(with = \"serde_with::As::<Option<serde_with::hex::Hex>>\")]",
+        )
+        .field_attribute("BackupId.id", "#[serde(with = \"serde_with::As::<serde_with::hex::Hex>\")]")
+        .field_attribute("ServiceId.id", "#[serde(with = \"serde_with::As::<serde_with::hex::Hex>\")]")
         .extern_path(".protobufs.kbupd_client", "kbupd_client")
         .compile_protos(&["src/kbupd.proto"], &["src/", "../kbupd_client/src/"])
         .expect("error compiling protobufs");


### PR DESCRIPTION
Adds `--json` flag to the `kubupctl status` command, allowing external processes to parse the output and react accordingly